### PR TITLE
Properly handle self-assignment

### DIFF
--- a/Chapter4_Trees/AVLTree/AvlTree.h
+++ b/Chapter4_Trees/AVLTree/AvlTree.h
@@ -61,6 +61,9 @@ public:
      */
     AvlTree &operator=(const AvlTree &rhs)
     {
+        if (this == &rhs) {
+            return *this;
+        }
         makeEmpty();
         root = clone(rhs.root);
         return *this;


### PR DESCRIPTION
Addresses a Clang-Tidy warning. Ensures efficient and safe assignment.